### PR TITLE
Fix sed command in zsh_setup.sh script

### DIFF
--- a/scripts/zsh_setup.sh
+++ b/scripts/zsh_setup.sh
@@ -44,7 +44,11 @@ validateSettings()
 configureZsh()
 {
     # Remove previous settings
-    sed -i '' '/### Codex CLI setup - start/,/### Codex CLI setup - end/d' $zshrcPath
+    if [ "$(uname)" = "Linux" ]; then
+        sed -i '/### Codex CLI setup - start/,/### Codex CLI setup - end/d' $zshrcPath
+    else
+        sed -i '' '/### Codex CLI setup - start/,/### Codex CLI setup - end/d' $zshrcPath
+    fi
     echo "Removed previous settings in $zshrcPath if present"
 
     # Update the latest settings


### PR DESCRIPTION
Add a check to determine if the script is running on a Linux system before calling the 'sed' command.

* Use the GNU version of `sed` if the script is running on a Linux system.
* Use the BSD version of `sed` if the script is not running on a Linux system.

