### PR TITLE
Fix URL replacement in setup scripts

### DIFF
--- a/scripts/bash_setup.sh
+++ b/scripts/bash_setup.sh
@@ -56,11 +56,10 @@ askSettings()
 }
 
 # Call OpenAI API with the given settings to verify everything is in order
-# API call to https://api.openai.com/v1/engines is a potential risk in the future because the route is deprecated
 validateSettings()
 {
     echo -n "*** Testing Open AI access... "
-    local TEST=$(curl -s 'https://api.openai.com/v1/engines' -H "Authorization: Bearer $SECRET_KEY" -H "OpenAI-Organization: $ORG_ID" -w '%{http_code}')
+    local TEST=$(curl -s 'https://api.openai.com/v1/models' -H "Authorization: Bearer $SECRET_KEY" -H "OpenAI-Organization: $ORG_ID" -w '%{http_code}')
     local STATUS_CODE=$(echo "$TEST"|tail -n 1)
     if [ $STATUS_CODE -ne 200 ]; then
         echo "ERROR [$STATUS_CODE]"

--- a/scripts/powershell_setup.ps1
+++ b/scripts/powershell_setup.ps1
@@ -43,9 +43,8 @@ if ($PSMajorVersion -lt 7) {
 }
 
 # Check the access with OpenAI API
-# API call to https://api.openai.com/v1/engines is a potential risk in the future because the route is deprecated
 Write-Host "Checking OpenAI access..."
-$testApiUri = "https://api.openai.com/v1/engines"
+$testApiUri = "https://api.openai.com/v1/models"
 $response = $null
 try {
     if ($PSMajorVersion -lt 7) {

--- a/scripts/zsh_setup.sh
+++ b/scripts/zsh_setup.sh
@@ -13,11 +13,10 @@
 set -e
 
 # Call OpenAI API with the given settings to verify everything is in order
-# API call to https://api.openai.com/v1/engines is a potential risk in the future because the route is deprecated
 validateSettings()
 {
     echo -n "*** Testing Open AI access... "
-    local TEST=$(curl -s 'https://api.openai.com/v1/engines' -H "Authorization: Bearer $secret" -H "OpenAI-Organization: $orgId" -w '%{http_code}')
+    local TEST=$(curl -s 'https://api.openai.com/v1/models' -H "Authorization: Bearer $secret" -H "OpenAI-Organization: $orgId" -w '%{http_code}')
     local STATUS_CODE=$(echo "$TEST"|tail -n 1)
     if [ $STATUS_CODE -ne 200 ]; then
         echo "ERROR [$STATUS_CODE]"


### PR DESCRIPTION
Replace 'engines' with 'models' in the URL in the 'validateSettings' function in all setup scripts.

* **scripts/bash_setup.sh**
  - Replace 'engines' with 'models' in the URL in the 'validateSettings' function.
  - Remove the comment about a potential risk from deprecation of the URL.

* **scripts/powershell_setup.ps1**
  - Replace 'engines' with 'models' in the URL in the 'validateSettings' function.
  - Remove the comment about a potential risk from deprecation of the URL.

* **scripts/zsh_setup.sh**
  - Replace 'engines' with 'models' in the URL in the 'validateSettings' function.
  - Remove the comment about a potential risk from deprecation of the URL.

